### PR TITLE
Sequence remove menu (#63)

### DIFF
--- a/Software/Production/SequencerState.py
+++ b/Software/Production/SequencerState.py
@@ -319,9 +319,55 @@ class SamplerMenuState(State):
                     # Exit editing menu
                     editing_sequence = False
 
+            # Select sequence
+            selected_sequence = self.select_sequence(
+                file_sequences.files
+            )  # Modify to index based on selected
 
-    def remove_sequence(self, fsequences):
-        pass
+            # Display
+            text = f"Edit {file_sequences.files[selected_sequence]}"
+            text_area = label.Label(terminalio.FONT, text=text, x=2, y=15)
+            display.show(text_area)
+
+            file_sequences.show_sequence(selected_sequence)
+            neopixels.show()
+
+            while editing_sequence is True:
+                # Code to edit a sequence here
+                key_event = keys.events.get()
+                if key_event and key_event.pressed:
+                    key = key_event.key_number
+                    if key >= 0 and key <= 7:
+                        self.sequence_selector(
+                            file_sequences.sequences[selected_sequence],
+                            0,
+                            1,
+                            0.05,
+                            key,
+                        )
+                        file_sequences.show_sequence(selected_sequence)
+                        neopixels.show()
+
+                # Exit on click of select encoder
+                if key_event and key_event.pressed and key_event.key_number == 10:
+                    # Reset menu status
+                    self.highlight = 1
+                    self.shift = 0
+                    # Exit editing menu
+                    editing_sequence = False
+
+    def remove_sequence(self):
+        # Check if sequences exist
+        if len(file_sequences.files) == 0:
+            text = "No Active Sequences"
+            text_area = label.Label(terminalio.FONT, text=text, x=2, y=15)
+            display.show(text_area)
+            time.sleep(0.5)
+
+        else:
+            selected_sequence = self.select_sequence(file_sequences.files)
+            del file_sequences.files[selected_sequence]
+            del file_sequences.sequences[selected_sequence]
 
     def update(self, machine):
         selection = ""
@@ -356,6 +402,11 @@ class SamplerMenuState(State):
             wav_file = self.select_wav()
             file_sequences.add_sequence(wav_file)
             show_menu(self.menu_items, self.highlight, self.shift)
+
+        if selection == "remove_sequence":
+            self.remove_sequence()
+            show_menu(self.menu_items, self.highlight, self.shift)
+
         if selection == "edit_sequence":
             self.edit_sequence(file_sequences)
             show_menu(self.menu_items, self.highlight, self.shift)

--- a/Software/Production/utils.py
+++ b/Software/Production/utils.py
@@ -57,7 +57,9 @@ def show_menu(menu, highlight, shift):
         try:
             short_list.append(menu[index]["pretty"])
         except IndexError:
-            print("show_menu: Bad Index")
+            pass
+            # Supressing this because it can show up just with short lists
+            # print("show_menu: Bad Index")
     for item in short_list:
         if highlight == line:
             white_rectangle = displayio.TileGrid(


### PR DESCRIPTION
* Sampler bugfixes and slight menu improvements

Correction in neopixel mapping

Added sampled (kick too low for speaker, but works on headphones)

Changed default MIDI channel to 1

* Fixing LED indexing in MIDI controller and HID Controller Improving menu flow in sampler

* Add remove sequence function in SamplerMenuState Supressed print statement in menu function
i
---------