### PR TITLE
Bugfix for Resolume functionality

### DIFF
--- a/Software/Production/MIDIState.py
+++ b/Software/Production/MIDIState.py
@@ -144,6 +144,9 @@ class MIDIState(State):
             self.last_volume_position = volume_enc.position
 
     def update(self, machine):
+        # Listen on USB MIDI, resolves issues with some software
+        # TODO Make this more elegant
+        midi_usb.receive()
         key_event = keys.events.get()
         if key_event:
             if key_event.key_number < 8:

--- a/Software/Production/setup.py
+++ b/Software/Production/setup.py
@@ -59,7 +59,7 @@ midi_serial = adafruit_midi.MIDI(
     midi_out=midi_uart, out_channel=midi_serial_channel - 1
 )
 
-midi_usb = adafruit_midi.MIDI(midi_out=usb_midi.ports[1], out_channel=0)
+midi_usb = adafruit_midi.MIDI(midi_in=usb_midi.ports[0], midi_out=usb_midi.ports[1], out_channel=0)
 
 # Setup the SD card and mount it as /sd
 try:


### PR DESCRIPTION
Fixes issue of Resolume hanging when badge is attached via USB MIDI. Badge does need to be in MIDI controller mode to prevent the hang from happening.